### PR TITLE
fix(cli): inject explicit --task binding into sdk run prompt

### DIFF
--- a/packages/cli/src/commands/sdk/run.ts
+++ b/packages/cli/src/commands/sdk/run.ts
@@ -46,7 +46,7 @@ export interface SdkRunResult {
 }
 
 const DEFAULT_PROMPT =
-  "Trellis SDK RUN (S1 worker): confirm task path binding; do not call integrate-child or start-execution --approved; summarize readiness in one short paragraph.";
+  "Trellis SDK RUN (S1 worker): confirm task path binding by restating the absolute taskPath; do not call integrate-child or start-execution --approved; summarize readiness in one short paragraph.";
 
 function resolveTaskPath(taskArg: string): string {
   return path.resolve(process.cwd(), taskArg);
@@ -59,9 +59,33 @@ function assertTaskDir(taskPath: string): void {
   const prd = path.join(taskPath, "prd.md");
   if (!fs.existsSync(prd)) {
     throw new Error(
-      `Task path missing prd.md (refusing unbound SDK RUN): ${prd}`,
+      `Task path missing prd.md (refusing unbound SDK RUN; pass --task <dir> that contains prd.md): ${prd}`,
     );
   }
+}
+
+/**
+ * Build the Agent prompt for SDK RUN. Always prepends an explicit --task binding
+ * block so SessionStart "Selected task: none" cannot be misread as unbound.
+ */
+export function buildSdkRunPrompt(
+  taskPath: string,
+  userPrompt?: string,
+): string {
+  const absoluteTask = path.resolve(taskPath);
+  const prdPath = path.join(absoluteTask, "prd.md");
+  const instruction = userPrompt?.trim() || DEFAULT_PROMPT;
+  return [
+    "## SDK RUN task binding (authoritative)",
+    `- Bound via CLI \`--task\` (not \`selected_task\` / SessionStart).`,
+    `- taskPath (absolute): \`${absoluteTask}\``,
+    `- prd.md (absolute): \`${prdPath}\``,
+    `- Binding status: **BOUND**.`,
+    `- Do **not** report unbound solely because SessionStart says \`Selected task: none\` — that pointer is irrelevant for SDK RUN.`,
+    "",
+    "## Instructions",
+    instruction,
+  ].join("\n");
 }
 
 async function runMockAgent(prompt: string): Promise<{
@@ -241,7 +265,7 @@ export async function runSdkRun(options: SdkRunOptions): Promise<SdkRunResult> {
   assertTaskDir(taskPath);
 
   const cwd = options.cwd ? path.resolve(options.cwd) : process.cwd();
-  const prompt = options.prompt?.trim() ?? DEFAULT_PROMPT;
+  const prompt = buildSdkRunPrompt(taskPath, options.prompt);
   const evidencePath =
     options.evidencePath ??
     path.join(taskPath, "research", "sdk-run-dogfood.md");

--- a/packages/cli/test/commands/sdk-run.test.ts
+++ b/packages/cli/test/commands/sdk-run.test.ts
@@ -5,7 +5,10 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { startRpcServe } from "../../src/commands/rpc/index.js";
-import { runSdkRun } from "../../src/commands/sdk/run.js";
+import {
+  buildSdkRunPrompt,
+  runSdkRun,
+} from "../../src/commands/sdk/run.js";
 import { collectSdkStatus } from "../../src/commands/sdk/status.js";
 
 const handles: { close(): Promise<void> }[] = [];
@@ -29,6 +32,31 @@ function makeTaskDir(): string {
   return dir;
 }
 
+describe("buildSdkRunPrompt", () => {
+  it("embeds absolute --task path and BOUND semantics", () => {
+    const task = makeTaskDir();
+    const prompt = buildSdkRunPrompt(task);
+    expect(prompt).toContain(task);
+    expect(prompt).toContain(path.join(task, "prd.md"));
+    expect(prompt).toMatch(/Binding status: \*\*BOUND\*\*/);
+    expect(prompt).toMatch(/Bound via CLI `--task`/);
+    expect(prompt).toMatch(/Do \*\*not\*\* report unbound solely because SessionStart/);
+    expect(prompt).toMatch(/Selected task: none/);
+    // Must not instruct the worker that missing selected_task means unbound.
+    expect(prompt).not.toMatch(/hence unbound|therefore unbound|unbound because Selected task/i);
+  });
+
+  it("keeps binding preamble when custom --prompt replaces instruction body", () => {
+    const task = makeTaskDir();
+    const custom = "Custom worker body: echo only READY.";
+    const prompt = buildSdkRunPrompt(task, custom);
+    expect(prompt).toContain(task);
+    expect(prompt).toMatch(/Binding status: \*\*BOUND\*\*/);
+    expect(prompt).toContain(custom);
+    expect(prompt).not.toContain("summarize readiness in one short paragraph");
+  });
+});
+
 describe("cstl sdk run", () => {
   it("rejects missing --task directory / prd.md", async () => {
     await expect(
@@ -39,6 +67,22 @@ describe("cstl sdk run", () => {
         noRpc: true,
       }),
     ).rejects.toThrow(/not a directory|missing prd\.md/);
+  });
+
+  it("mock RUN prompt binding reaches agent (path in mock result length path via evidence)", async () => {
+    const task = makeTaskDir();
+    const result = await runSdkRun({
+      task,
+      campaign: "sdk-test",
+      mode: "mock",
+      noRpc: true,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.taskPath).toBe(path.resolve(task));
+    // Mock agent reports prompt length; binding preamble makes prompt longer than DEFAULT alone.
+    const bound = buildSdkRunPrompt(task);
+    expect(result.agent.result).toContain(String(bound.length));
+    expect(bound.length).toBeGreaterThan(200);
   });
 
   it("mock RUN writes dogfood and skips RPC when --no-rpc", async () => {


### PR DESCRIPTION
## Summary
- Prepend an authoritative `--task` binding block in `buildSdkRunPrompt` so live SDK workers do not treat SessionStart `Selected task: none` as unbound when CLI already passed `--task` + `prd.md`.
- Add Vitest coverage for the prompt contract and binding length regression.
- Live dogfood (`runId=f3f1a5f5`) confirmed agent reports task as bound.

## Test plan
- [x] `pnpm exec vitest run packages/cli/test/commands/sdk-run.test.ts`
- [x] Live dogfood evidence under archived task `08-03-sdk-live-task-binding`
- [ ] Merge + `Rebuild-CstlLocal` on MyHarness before next live SDK run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect CLI prompt text and tests for SDK RUN; no auth, RPC, or task validation logic changes beyond clearer errors.
> 
> **Overview**
> Live SDK RUN workers were sometimes treating SessionStart **`Selected task: none`** as “unbound” even when the CLI already passed **`--task`** and **`prd.md`** existed. This change makes task binding explicit in the agent prompt instead of relying on session context.
> 
> **`buildSdkRunPrompt`** prepends an authoritative binding section (absolute `taskPath`, `prd.md` path, **BOUND** status) and states that SessionStart’s selected task is irrelevant for SDK RUN. **`runSdkRun`** always builds the prompt through that helper (default or custom **`--prompt`** body under **Instructions**). Default worker text and the missing-`prd.md` error message are slightly clearer.
> 
> Vitest covers the prompt contract (paths, BOUND semantics, custom prompt keeps preamble) and that mock runs send the longer bound prompt to the agent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30c281b75550365a09d110845a0ae48d90693a9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->