### PR TITLE
fix(cli): speak NDJSON for campaign MCP stdio under Cursor

### DIFF
--- a/docs/campaign-ui.md
+++ b/docs/campaign-ui.md
@@ -70,8 +70,8 @@ cstl campaign canvas --parent .cstl/tasks/<campaign-parent>
 {
   "mcpServers": {
     "trellis-campaign": {
-      "command": "cstl",
-      "args": ["campaign", "mcp"]
+      "command": "npx",
+      "args": ["-y", "@blxzer/cursor-trellis", "campaign", "mcp"]
     }
   }
 }

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -171,7 +171,7 @@ Init/update can also select:
 | Capability id | What it does | Gate |
 | --- | --- | --- |
 | `cursor-sdk` | Records SDK RUN enablement + readiness; uses the **CLI-bundled** `@cursor/sdk` (does not add npm deps to your app) | Requires `CURSOR_API_KEY` in the **current process**. Checkbox stays visible; without a key Trellis **skips enablement** and prints setup steps. |
-| `campaign-mcp` | Merges `trellis-campaign` (`cstl campaign mcp`) into project `.cursor/mcp.json` | No API key. Does **not** write `TRELLIS_CAMPAIGN_PARENT` into mcp.json — set env / `--parent` / tool args yourself. |
+| `campaign-mcp` | Merges `trellis-campaign` (`npx -y @blxzer/cursor-trellis campaign mcp`) into project `.cursor/mcp.json` | No API key. Does **not** write `TRELLIS_CAMPAIGN_PARENT` into mcp.json — set env / `--parent` / tool args yourself. |
 
 MCP writes **merge** into existing `.cursor/mcp.json`: Trellis-managed server names are upserted/removed from the current selection; unrelated servers are preserved.
 

--- a/docs/cursor.zh-CN.md
+++ b/docs/cursor.zh-CN.md
@@ -170,7 +170,7 @@ init/update 还可勾选：
 | 能力 id | 作用 | 门禁 |
 | --- | --- | --- |
 | `cursor-sdk` | 记录 SDK RUN 启用与 readiness；使用 **CLI 自带** `@cursor/sdk`（不向业务项目加 npm 依赖） | 需要当前进程有 `CURSOR_API_KEY`。选项始终展示；无 key 时**跳过启用**并打印设置指引。 |
-| `campaign-mcp` | 把 `trellis-campaign`（`cstl campaign mcp`）**merge** 进项目 `.cursor/mcp.json` | 无需 API key。**不**把 `TRELLIS_CAMPAIGN_PARENT` 写入 mcp.json——请自行设 env / `--parent` / 工具参数。 |
+| `campaign-mcp` | 把 `trellis-campaign`（`npx -y @blxzer/cursor-trellis campaign mcp`）**merge** 进项目 `.cursor/mcp.json` | 无需 API key。**不**把 `TRELLIS_CAMPAIGN_PARENT` 写入 mcp.json——请自行设 env / `--parent` / 工具参数。 |
 
 MCP 写入为 **merge**：Trellis 托管的 server 名按当前选择 upsert/删除；用户自有 server 保留。
 

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -56,9 +56,12 @@ function checkForUpdates(cwd: string): void {
   }
 }
 
-// Check for updates at CLI startup when a workflow dir exists
+// Check for updates at CLI startup when a workflow dir exists.
+// Never print to stdout when running an MCP stdio server — Cursor hosts
+// treat any non-framed stdout as a handshake failure.
 const cwd = process.cwd();
-if (isWorkflowInitialized(cwd)) {
+const isStdioMcp = process.argv.slice(2).includes("mcp");
+if (isWorkflowInitialized(cwd) && !isStdioMcp) {
   checkForUpdates(cwd);
 }
 

--- a/packages/cli/src/commands/campaign/mcp-server.ts
+++ b/packages/cli/src/commands/campaign/mcp-server.ts
@@ -9,10 +9,12 @@ interface JsonRpcRequest {
   params?: unknown;
 }
 
+/**
+ * MCP stdio framing used by @modelcontextprotocol/sdk (and Cursor host):
+ * one JSON-RPC message per line (NDJSON). Not LSP Content-Length.
+ */
 function writeMessage(message: unknown): void {
-  const body = JSON.stringify(message);
-  const header = `Content-Length: ${Buffer.byteLength(body, "utf8")}\r\n\r\n`;
-  process.stdout.write(header + body);
+  process.stdout.write(`${JSON.stringify(message)}\n`);
 }
 
 function ok(id: JsonRpcId, result: unknown): void {
@@ -83,14 +85,26 @@ async function callCampaignStatus(params: unknown): Promise<string> {
   return JSON.stringify(snapshot, null, 2);
 }
 
+function negotiatedProtocolVersion(params: unknown): string {
+  const p =
+    params && typeof params === "object"
+      ? (params as Record<string, unknown>)
+      : {};
+  const requested =
+    typeof p.protocolVersion === "string" ? p.protocolVersion.trim() : "";
+  return requested || "2024-11-05";
+}
+
 async function handleRequest(msg: JsonRpcRequest): Promise<void> {
   const method = msg.method ?? "";
   const id = msg.id ?? null;
 
   if (method === "initialize") {
     ok(id, {
-      protocolVersion: "2024-11-05",
-      capabilities: { tools: {} },
+      protocolVersion: negotiatedProtocolVersion(msg.params),
+      capabilities: {
+        tools: {},
+      },
       serverInfo: { name: "trellis-campaign", version: "0.1.0" },
     });
     return;
@@ -107,6 +121,16 @@ async function handleRequest(msg: JsonRpcRequest): Promise<void> {
 
   if (method === "tools/list") {
     ok(id, toolList());
+    return;
+  }
+
+  if (method === "resources/list") {
+    ok(id, { resources: [] });
+    return;
+  }
+
+  if (method === "prompts/list") {
+    ok(id, { prompts: [] });
     return;
   }
 
@@ -139,35 +163,23 @@ async function handleRequest(msg: JsonRpcRequest): Promise<void> {
 }
 
 /**
- * Run minimal MCP stdio server (Content-Length framing).
+ * Run MCP stdio server (newline-delimited JSON-RPC, SDK dialect).
  * Blocks until stdin closes.
  */
 export async function runCampaignMcpServer(): Promise<void> {
-  let buffer = Buffer.alloc(0);
+  let buffer = "";
+  let chain: Promise<void> = Promise.resolve();
 
-  const processBuffer = async (): Promise<void> => {
+  const processLines = async (): Promise<void> => {
     while (true) {
-      let headerEnd = buffer.indexOf("\r\n\r\n");
-      let sepLen = 4;
-      if (headerEnd === -1) {
-        headerEnd = buffer.indexOf("\n\n");
-        sepLen = 2;
-      }
-      if (headerEnd === -1) return;
-      const header = buffer.subarray(0, headerEnd).toString("utf8");
-      const match = /Content-Length:\s*(\d+)/i.exec(header);
-      if (!match) {
-        buffer = buffer.subarray(headerEnd + sepLen);
-        continue;
-      }
-      const length = Number(match[1]);
-      const bodyStart = headerEnd + sepLen;
-      if (buffer.length < bodyStart + length) return;
-      const body = buffer.subarray(bodyStart, bodyStart + length).toString("utf8");
-      buffer = buffer.subarray(bodyStart + length);
+      const index = buffer.indexOf("\n");
+      if (index === -1) return;
+      const line = buffer.slice(0, index).replace(/\r$/, "").trim();
+      buffer = buffer.slice(index + 1);
+      if (!line) continue;
       let msg: JsonRpcRequest;
       try {
-        msg = JSON.parse(body) as JsonRpcRequest;
+        msg = JSON.parse(line) as JsonRpcRequest;
       } catch {
         continue;
       }
@@ -175,9 +187,14 @@ export async function runCampaignMcpServer(): Promise<void> {
     }
   };
 
-  process.stdin.on("data", (chunk: Buffer) => {
-    buffer = Buffer.concat([buffer, chunk]);
-    void processBuffer();
+  if (typeof process.stdin.resume === "function") {
+    process.stdin.resume();
+  }
+  process.stdin.setEncoding("utf8");
+
+  process.stdin.on("data", (chunk: string | Buffer) => {
+    buffer += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    chain = chain.then(() => processLines()).catch(() => undefined);
   });
 
   await new Promise<void>((resolve) => {

--- a/packages/cli/src/utils/project-capabilities.ts
+++ b/packages/cli/src/utils/project-capabilities.ts
@@ -352,8 +352,10 @@ export const PROJECT_CAPABILITIES: readonly ProjectCapability[] = [
     mcpServers: [
       {
         name: "trellis-campaign",
-        command: "cstl",
-        args: ["campaign", "mcp"],
+        // Match other optional MCP entries: npx -y <published package> …
+        // (Bare `cstl` breaks on Windows shims and unpublished global installs.)
+        command: "npx",
+        args: ["-y", "@blxzer/cursor-trellis", "campaign", "mcp"],
       },
     ],
   },

--- a/packages/cli/test/commands/campaign-mcp.test.ts
+++ b/packages/cli/test/commands/campaign-mcp.test.ts
@@ -16,21 +16,27 @@ const cliRoot = path.resolve(
 );
 const distCli = path.join(cliRoot, "dist", "cli", "index.js");
 const harnessRoot = path.resolve(cliRoot, "../../../..");
-const parent = path.join(
-  harnessRoot,
-  ".cstl",
-  "tasks",
-  "08-01-trellis-intent-multisession",
-);
+const parentCandidates = [
+  path.join(
+    harnessRoot,
+    ".cstl",
+    "tasks",
+    "archive",
+    "2026-08",
+    "08-01-trellis-intent-multisession",
+  ),
+  path.join(harnessRoot, ".cstl", "tasks", "08-01-trellis-intent-multisession"),
+];
+const parent =
+  parentCandidates.find((p) => fs.existsSync(p)) ?? parentCandidates[0];
 
+/** Official MCP TS SDK stdio dialect: one JSON-RPC object per line. */
 function encodeMcp(message: unknown): Buffer {
-  const body = JSON.stringify(message);
-  const header = `Content-Length: ${Buffer.byteLength(body, "utf8")}\r\n\r\n`;
-  return Buffer.from(header + body, "utf8");
+  return Buffer.from(`${JSON.stringify(message)}\n`, "utf8");
 }
 
 class McpClient {
-  private buffer = Buffer.alloc(0);
+  private buffer = "";
   private waiters: {
     resolve: (value: unknown) => void;
     reject: (error: Error) => void;
@@ -38,42 +44,25 @@ class McpClient {
   }[] = [];
 
   constructor(private readonly child: ReturnType<typeof spawn>) {
-    child.stdout?.on("data", (chunk: Buffer) => {
-      this.buffer = Buffer.concat([this.buffer, chunk]);
+    child.stdout?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      this.buffer += chunk;
       this.drain();
     });
   }
 
-  private splitHeader(buf: Buffer): { headerEnd: number; sepLen: number } | null {
-    const crlf = buf.indexOf("\r\n\r\n");
-    if (crlf !== -1) return { headerEnd: crlf, sepLen: 4 };
-    const lf = buf.indexOf("\n\n");
-    if (lf !== -1) return { headerEnd: lf, sepLen: 2 };
-    return null;
-  }
-
   private drain(): void {
     while (this.waiters.length > 0) {
-      const split = this.splitHeader(this.buffer);
-      if (!split) return;
-      const header = this.buffer.subarray(0, split.headerEnd).toString("utf8");
-      const match = /Content-Length:\s*(\d+)/i.exec(header);
-      if (!match) {
-        this.buffer = this.buffer.subarray(split.headerEnd + split.sepLen);
-        continue;
-      }
-      const length = Number(match[1]);
-      const bodyStart = split.headerEnd + split.sepLen;
-      if (this.buffer.length < bodyStart + length) return;
-      const body = this.buffer
-        .subarray(bodyStart, bodyStart + length)
-        .toString("utf8");
-      this.buffer = this.buffer.subarray(bodyStart + length);
+      const index = this.buffer.indexOf("\n");
+      if (index === -1) return;
+      const line = this.buffer.slice(0, index).replace(/\r$/, "").trim();
+      this.buffer = this.buffer.slice(index + 1);
+      if (!line) continue;
       const waiter = this.waiters.shift();
       if (!waiter) return;
       clearTimeout(waiter.timer);
       try {
-        waiter.resolve(JSON.parse(body));
+        waiter.resolve(JSON.parse(line));
       } catch (error) {
         waiter.reject(
           error instanceof Error ? error : new Error(String(error)),
@@ -180,5 +169,5 @@ describe("campaign mcp stdio", () => {
     } finally {
       client.close();
     }
-  }, 45_000);
+  });
 });

--- a/packages/cli/test/utils/project-capabilities.test.ts
+++ b/packages/cli/test/utils/project-capabilities.test.ts
@@ -138,8 +138,8 @@ describe("project capabilities", () => {
       args: ["custom-server.js"],
     });
     expect(merged.mcpServers["trellis-campaign"]).toEqual({
-      command: "cstl",
-      args: ["campaign", "mcp"],
+      command: "npx",
+      args: ["-y", "@blxzer/cursor-trellis", "campaign", "mcp"],
     });
     // managed github deselected → removed
     expect(merged.mcpServers.github).toBeUndefined();
@@ -172,7 +172,7 @@ describe("project capabilities", () => {
         command: "echo",
         args: ["ok"],
       });
-      expect(parsed.mcpServers["trellis-campaign"].command).toBe("cstl");
+      expect(parsed.mcpServers["trellis-campaign"].command).toBe("npx");
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- Align `campaign mcp` stdio framing with Cursor / `@modelcontextprotocol/sdk` (newline-delimited JSON-RPC instead of LSP `Content-Length`).
- Skip CLI update banners when argv includes `mcp` so stdout stays clean for handshake.
- Update capability/docs launch template toward `npx -y @blxzer/cursor-trellis campaign mcp` (publish deferred).

## Test plan
- [x] `pnpm exec vitest run test/commands/campaign-mcp.test.ts test/utils/project-capabilities.test.ts` (15 PASS)
- [x] Official SDK `Client.connect` + `listTools` against local `bin/cstl.js campaign mcp`
- [x] Cursor IDE dogfood: `trellis-campaign` `ready` + live `campaign_status` call
- [ ] No npm publish in this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> MCP transport and CLI stdout behavior directly affect Cursor handshake reliability; the `npx` launch path changes how the merged `.cursor/mcp.json` entry starts the server (still read-only observation).
> 
> **Overview**
> Fixes **Cursor / MCP SDK handshake** for the read-only `trellis-campaign` server by switching `campaign mcp` stdio from LSP **`Content-Length`** framing to **newline-delimited JSON-RPC** (one message per line), matching `@modelcontextprotocol/sdk`.
> 
> The stdio server also **negotiates `protocolVersion` on `initialize`**, answers **`resources/list`** and **`prompts/list`** with empty lists, and processes stdin as UTF-8 with ordered line handling. **CLI startup no longer prints Trellis update banners** when `argv` includes `mcp`, so stdout stays clean for the host.
> 
> **`campaign-mcp` capability templates and docs** now launch via `npx -y @blxzer/cursor-trellis campaign mcp` instead of bare `cstl` (Windows shims / unpublished globals). Tests and harness parent paths were updated for NDJSON and the new launch command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b14ea20feb7bfbd1d7955ed752462c89abda80d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->