### PR TITLE
fix(cli): guard campaign canvas open path for Cursor Canvas view

### DIFF
--- a/docs/campaign-ui.md
+++ b/docs/campaign-ui.md
@@ -61,23 +61,26 @@ Overrides (portable escape hatches):
 | --- | --- |
 | `TRELLIS_CAMPAIGN_CANVAS_DIR` / `CURSOR_CANVAS_DIR` | Absolute canvases directory |
 | `TRELLIS_CURSOR_PROJECT_SLUG` | Force `~/.cursor/projects/<slug>/canvases` when auto-slug is wrong |
-| `TRELLIS_CAMPAIGN_CANVAS_OPEN=1` | Same as `--open` |
+| `TRELLIS_CAMPAIGN_CANVAS_OPEN=0` | Disable default auto-open (`1` forces open) |
 | `CURSOR_BIN` | Cursor CLI binary when not on PATH |
 
 ```powershell
+# Interactive (default): write + best-effort open in Cursor
+cstl campaign canvas --parent .cstl/tasks/<campaign-parent>
+
 # Optional: pin --out ONLY when the path stays under *your* canvases dir
 cstl campaign canvas --parent .cstl/tasks/<campaign-parent> --out "$env:USERPROFILE\.cursor\projects\<your-slug>\canvases\campaign-<id>.canvas.tsx"
 
-# Script-friendly: stdout = path only
+# Script-friendly: stdout = path only, no IDE popup
 cstl campaign canvas --parent .cstl/tasks/<campaign-parent> --quiet
 
-# Best-effort open via Cursor CLI (may still open as text; use Canvas view if needed)
-cstl campaign canvas --parent .cstl/tasks/<campaign-parent> --open
+# Write without opening (still prints hints unless --quiet)
+cstl campaign canvas --parent .cstl/tasks/<campaign-parent> --no-open
 ```
 
 **Do not** use `--out` to dump into `.cstl/workspace/...` or other repo paths unless you only want a source copy — the CLI still writes the file but prints a **warning**, and a normal editor will not render Canvas graphics.
 
-After a successful write, stdout prints the absolute path; stderr prints open hints (and a warning when the path is outside canvases) unless `--quiet`. Re-run the same command to refresh.
+After a successful write, stdout prints the absolute path. By default the CLI also tries to open the file via the Cursor shell command so you can see the Canvas UI. Use `--quiet` in scripts. Re-run the same command to refresh.
 
 **Native and BYOK:** Canvas is IDE-local React compiled from `.canvas.tsx`; it works for both Native and BYOK sessions (does not depend on the official model billing channel).
 

--- a/docs/campaign-ui.md
+++ b/docs/campaign-ui.md
@@ -40,6 +40,12 @@ Broker down is OK: Trellis stages/children still render; RPC section shows `reac
 > If you open the same `.canvas.tsx` from elsewhere (for example `.cstl/workspace/...`)
 > in a normal editor tab, you will see **TypeScript source only** — not the campaign UI.
 > Always open the printed path in the Cursor **Canvas** view.
+>
+> **User environments differ.** Do not assume a specific machine path, drive letter, or
+> Cursor project folder name. Prefer the CLI default (derived from the harness root +
+> `os.homedir()`). If Cursor’s project slug does not match the derived one, set
+> `TRELLIS_CURSOR_PROJECT_SLUG` or point `TRELLIS_CAMPAIGN_CANVAS_DIR` at the canvases
+> folder that your IDE actually uses.
 
 Generate or refresh a Cursor Canvas with an **embedded** campaign snapshot (no `fetch()` inside the canvas):
 
@@ -49,16 +55,29 @@ cstl campaign canvas --parent .cstl/tasks/<campaign-parent>
 ```
 
 Default write target: `~/.cursor/projects/<workspace-slug>/canvases/campaign-<parentId>.canvas.tsx`  
-(override with env `TRELLIS_CAMPAIGN_CANVAS_DIR` / `CURSOR_CANVAS_DIR`).
+Overrides (portable escape hatches):
+
+| Env | Purpose |
+| --- | --- |
+| `TRELLIS_CAMPAIGN_CANVAS_DIR` / `CURSOR_CANVAS_DIR` | Absolute canvases directory |
+| `TRELLIS_CURSOR_PROJECT_SLUG` | Force `~/.cursor/projects/<slug>/canvases` when auto-slug is wrong |
+| `TRELLIS_CAMPAIGN_CANVAS_OPEN=1` | Same as `--open` |
+| `CURSOR_BIN` | Cursor CLI binary when not on PATH |
 
 ```powershell
-# Optional: pin --out ONLY when the path stays under canvases (or your env canvas dir)
-cstl campaign canvas --parent .cstl/tasks/<campaign-parent> --out "$env:USERPROFILE\.cursor\projects\d-MyHarness\canvases\campaign-<id>.canvas.tsx"
+# Optional: pin --out ONLY when the path stays under *your* canvases dir
+cstl campaign canvas --parent .cstl/tasks/<campaign-parent> --out "$env:USERPROFILE\.cursor\projects\<your-slug>\canvases\campaign-<id>.canvas.tsx"
+
+# Script-friendly: stdout = path only
+cstl campaign canvas --parent .cstl/tasks/<campaign-parent> --quiet
+
+# Best-effort open via Cursor CLI (may still open as text; use Canvas view if needed)
+cstl campaign canvas --parent .cstl/tasks/<campaign-parent> --open
 ```
 
 **Do not** use `--out` to dump into `.cstl/workspace/...` or other repo paths unless you only want a source copy — the CLI still writes the file but prints a **warning**, and a normal editor will not render Canvas graphics.
 
-After a successful write, stdout prints the absolute path; stderr prints open hints (and a warning when the path is outside canvases). Re-run the same command to refresh.
+After a successful write, stdout prints the absolute path; stderr prints open hints (and a warning when the path is outside canvases) unless `--quiet`. Re-run the same command to refresh.
 
 **Native and BYOK:** Canvas is IDE-local React compiled from `.canvas.tsx`; it works for both Native and BYOK sessions (does not depend on the official model billing channel).
 

--- a/docs/campaign-ui.md
+++ b/docs/campaign-ui.md
@@ -31,19 +31,34 @@ Broker down is OK: Trellis stages/children still render; RPC section shows `reac
 
 ## Canvas path (IDE-local)
 
+> **Critical — where Canvas actually renders**
+>
+> Cursor only shows the **graphical** Canvas UI for files under:
+> `~/.cursor/projects/<workspace-slug>/canvases/*.canvas.tsx`
+> (or a directory set via `TRELLIS_CAMPAIGN_CANVAS_DIR` / `CURSOR_CANVAS_DIR`).
+>
+> If you open the same `.canvas.tsx` from elsewhere (for example `.cstl/workspace/...`)
+> in a normal editor tab, you will see **TypeScript source only** — not the campaign UI.
+> Always open the printed path in the Cursor **Canvas** view.
+
 Generate or refresh a Cursor Canvas with an **embedded** campaign snapshot (no `fetch()` inside the canvas):
 
 ```powershell
+# Preferred: write to the default canvases path (CLI mkdir if needed)
 cstl campaign canvas --parent .cstl/tasks/<campaign-parent>
-
-# Or pin the output path (recommended when auto-detect misses the project folder)
-cstl campaign canvas --parent .cstl/tasks/<campaign-parent> --out "$env:USERPROFILE\.cursor\projects\d-MyHarness\canvases\campaign-<id>.canvas.tsx"
 ```
 
 Default write target: `~/.cursor/projects/<workspace-slug>/canvases/campaign-<parentId>.canvas.tsx`  
-(override with `--out`, or env `TRELLIS_CAMPAIGN_CANVAS_DIR` / `CURSOR_CANVAS_DIR`).
+(override with env `TRELLIS_CAMPAIGN_CANVAS_DIR` / `CURSOR_CANVAS_DIR`).
 
-Open the printed `.canvas.tsx` beside chat (Cursor Canvas). Re-run the same command to refresh.
+```powershell
+# Optional: pin --out ONLY when the path stays under canvases (or your env canvas dir)
+cstl campaign canvas --parent .cstl/tasks/<campaign-parent> --out "$env:USERPROFILE\.cursor\projects\d-MyHarness\canvases\campaign-<id>.canvas.tsx"
+```
+
+**Do not** use `--out` to dump into `.cstl/workspace/...` or other repo paths unless you only want a source copy — the CLI still writes the file but prints a **warning**, and a normal editor will not render Canvas graphics.
+
+After a successful write, stdout prints the absolute path; stderr prints open hints (and a warning when the path is outside canvases). Re-run the same command to refresh.
 
 **Native and BYOK:** Canvas is IDE-local React compiled from `.canvas.tsx`; it works for both Native and BYOK sessions (does not depend on the official model billing channel).
 

--- a/packages/cli/src/commands/campaign/canvas-render.ts
+++ b/packages/cli/src/commands/campaign/canvas-render.ts
@@ -134,7 +134,8 @@ const OPEN_HINT =
   "Cursor only renders .canvas.tsx under ~/.cursor/projects/<slug>/canvases/ " +
   "(or TRELLIS_CAMPAIGN_CANVAS_DIR / CURSOR_CANVAS_DIR). " +
   "Opening outside that folder in a normal editor shows source only — no graphics. " +
-  "Use --open to best-effort launch Cursor on the file; use --quiet to suppress hints.";
+  "By default the CLI also opens this file via the Cursor shell command. " +
+  "Use --no-open to skip, --quiet for scripts (no hints, no open).";
 
 /**
  * Evaluate write destination for warnings/hints after `campaign canvas` succeeds.
@@ -212,11 +213,16 @@ export function tryOpenCanvasFile(absPath: string): CanvasOpenAttempt {
     };
   }
   try {
+    // Prefer argv form without shell when bin is an absolute .exe/.cmd path.
+    const useShell =
+      process.platform === "win32" &&
+      !path.isAbsolute(bin) &&
+      !/\.(exe|cmd|bat)$/i.test(bin);
     const child = spawn(bin, [abs], {
       detached: true,
       stdio: "ignore",
       windowsHide: true,
-      shell: process.platform === "win32",
+      shell: useShell,
     });
     child.unref();
     return {
@@ -236,10 +242,18 @@ export function tryOpenCanvasFile(absPath: string): CanvasOpenAttempt {
 
 export function shouldAutoOpenCanvas(opts?: {
   open?: boolean;
+  noOpen?: boolean;
+  quiet?: boolean;
 }): boolean {
+  // Scripts: --quiet means path-only, do not pop the IDE.
+  if (opts?.quiet === true) return false;
+  if (opts?.noOpen === true) return false;
   if (opts?.open === true) return true;
   const env = process.env.TRELLIS_CAMPAIGN_CANVAS_OPEN?.trim().toLowerCase();
-  return env === "1" || env === "true" || env === "yes";
+  if (env === "0" || env === "false" || env === "no") return false;
+  if (env === "1" || env === "true" || env === "yes") return true;
+  // Default ON: writing a canvas is useless if the user never sees it.
+  return true;
 }
 
 export function resolveHarnessForCanvas(parentDir: string): string | null {

--- a/packages/cli/src/commands/campaign/canvas-render.ts
+++ b/packages/cli/src/commands/campaign/canvas-render.ts
@@ -1,3 +1,4 @@
+import { execFileSync, spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -33,7 +34,9 @@ export function resolveCanvasesDir(harnessRoot: string | null): string | null {
   if (fromEnv) return path.resolve(fromEnv);
 
   if (!harnessRoot) return null;
-  const slug = cursorProjectSlug(harnessRoot);
+  const slug =
+    process.env.TRELLIS_CURSOR_PROJECT_SLUG?.trim() ||
+    cursorProjectSlug(harnessRoot);
   const candidate = path.join(
     os.homedir(),
     ".cursor",
@@ -43,23 +46,54 @@ export function resolveCanvasesDir(harnessRoot: string | null): string | null {
   );
   if (fs.existsSync(candidate)) return candidate;
 
-  // Soft match: prefer an existing project dir with matching slug (case).
-  // If ~/.cursor/projects is missing, still return the candidate so write can mkdir.
+  // Soft match unusual project folder names; if projects root is missing, still
+  // return the candidate so write can mkdir.
   const projectsRoot = path.join(os.homedir(), ".cursor", "projects");
   if (fs.existsSync(projectsRoot)) {
-    try {
-      const entries = fs.readdirSync(projectsRoot, { withFileTypes: true });
-      const exact = entries.find(
-        (e) => e.isDirectory() && e.name.toLowerCase() === slug.toLowerCase(),
-      );
-      if (exact) {
-        return path.join(projectsRoot, exact.name, "canvases");
-      }
-    } catch {
-      // ignore — fall through to candidate
-    }
+    const soft = softMatchCanvasesDir(projectsRoot, slug, harnessRoot);
+    if (soft) return soft;
   }
   return candidate;
+}
+
+/**
+ * Soft-match `~/.cursor/projects/<name>/canvases` when the exact slug folder
+ * is missing or differently cased / hyphenated.
+ * Does **not** pick longer nested names (e.g. `d-MyHarness-Trellis` for harness
+ * `D:\\MyHarness`) — those would steal writes from the canonical slug mkdir path.
+ * Skips pure-numeric agent project ids.
+ */
+export function softMatchCanvasesDir(
+  projectsRoot: string,
+  slug: string,
+  _harnessRoot: string,
+): string | null {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(projectsRoot, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  const dirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
+  const slugLower = slug.toLowerCase();
+  const slugNorm = slugLower.replace(/_/g, "-");
+
+  const exact = dirs.find((n) => n.toLowerCase() === slugLower);
+  if (exact) {
+    return path.join(projectsRoot, exact, "canvases");
+  }
+
+  // Same path slug with `_` vs `-` (or mixed), not a longer nested project name.
+  const normalized = dirs.find((n) => {
+    const lower = n.toLowerCase();
+    if (/^\d+$/.test(lower)) return false;
+    return lower.replace(/_/g, "-") === slugNorm;
+  });
+  if (normalized) {
+    return path.join(projectsRoot, normalized, "canvases");
+  }
+
+  return null;
 }
 
 /** True when `absPath` is under `canvasDir` (Windows case-insensitive). */
@@ -79,6 +113,15 @@ export function isUnderCanvasDir(
   return rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel);
 }
 
+/**
+ * Heuristic: path sits under `~/.cursor/projects/<any>/canvases/` even when
+ * `resolveCanvasesDir` returned null (no harness / no env).
+ */
+export function looksLikeCursorCanvasesPath(absPath: string): boolean {
+  const normalized = path.resolve(absPath).replace(/\\/g, "/").toLowerCase();
+  return /\/\.cursor\/projects\/[^/]+\/canvases\//.test(`${normalized}/`);
+}
+
 export type CanvasWriteEvaluation = {
   underCanvasDir: boolean;
   usedWorkspaceFallback: boolean;
@@ -90,7 +133,8 @@ const OPEN_HINT =
   "Open this file in Cursor Canvas view (not a normal text editor). " +
   "Cursor only renders .canvas.tsx under ~/.cursor/projects/<slug>/canvases/ " +
   "(or TRELLIS_CAMPAIGN_CANVAS_DIR / CURSOR_CANVAS_DIR). " +
-  "Opening outside that folder in a normal editor shows source only — no graphics.";
+  "Opening outside that folder in a normal editor shows source only — no graphics. " +
+  "Use --open to best-effort launch Cursor on the file; use --quiet to suppress hints.";
 
 /**
  * Evaluate write destination for warnings/hints after `campaign canvas` succeeds.
@@ -101,7 +145,8 @@ export function evaluateCanvasWritePath(
   canvasDir: string | null,
   opts?: { usedWorkspaceFallback?: boolean },
 ): CanvasWriteEvaluation {
-  const underCanvasDir = isUnderCanvasDir(absOut, canvasDir);
+  const underCanvasDir =
+    isUnderCanvasDir(absOut, canvasDir) || looksLikeCursorCanvasesPath(absOut);
   const usedWorkspaceFallback = opts?.usedWorkspaceFallback === true;
   const warnings: string[] = [];
   if (!underCanvasDir) {
@@ -124,6 +169,77 @@ export function evaluateCanvasWritePath(
     warnings,
     hints: [OPEN_HINT],
   };
+}
+
+export type CanvasOpenAttempt = {
+  attempted: boolean;
+  ok: boolean;
+  detail: string;
+};
+
+/**
+ * Best-effort open of a `.canvas.tsx` via the Cursor CLI (`cursor` / `CURSOR_BIN`).
+ * Does not guarantee Canvas view (IDE may open as text); callers still print hints.
+ */
+export function resolveCursorCliBin(): string | null {
+  const fromEnv = process.env.CURSOR_BIN?.trim();
+  if (fromEnv) return fromEnv;
+  try {
+    const finder = process.platform === "win32" ? "where.exe" : "which";
+    const out = execFileSync(finder, ["cursor"], {
+      encoding: "utf8",
+      windowsHide: true,
+    });
+    const first = out
+      .split(/\r?\n/)
+      .map((s) => s.trim())
+      .find(Boolean);
+    return first ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function tryOpenCanvasFile(absPath: string): CanvasOpenAttempt {
+  const abs = path.resolve(absPath);
+  const bin = resolveCursorCliBin();
+  if (!bin) {
+    return {
+      attempted: true,
+      ok: false,
+      detail:
+        "Cursor CLI not found on PATH (set CURSOR_BIN or install the `cursor` shell command)",
+    };
+  }
+  try {
+    const child = spawn(bin, [abs], {
+      detached: true,
+      stdio: "ignore",
+      windowsHide: true,
+      shell: process.platform === "win32",
+    });
+    child.unref();
+    return {
+      attempted: true,
+      ok: true,
+      detail: `spawned ${bin} ${abs}`,
+    };
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return {
+      attempted: true,
+      ok: false,
+      detail: `failed to spawn Cursor CLI (${bin}): ${msg}`,
+    };
+  }
+}
+
+export function shouldAutoOpenCanvas(opts?: {
+  open?: boolean;
+}): boolean {
+  if (opts?.open === true) return true;
+  const env = process.env.TRELLIS_CAMPAIGN_CANVAS_OPEN?.trim().toLowerCase();
+  return env === "1" || env === "true" || env === "yes";
 }
 
 export function resolveHarnessForCanvas(parentDir: string): string | null {

--- a/packages/cli/src/commands/campaign/canvas-render.ts
+++ b/packages/cli/src/commands/campaign/canvas-render.ts
@@ -20,7 +20,13 @@ export function cursorProjectSlug(absPath: string): string {
   return normalized.replace(/^\//, "").replace(/\/+/g, "-");
 }
 
-function resolveCanvasesDir(harnessRoot: string | null): string | null {
+/**
+ * Resolve the Cursor canvases directory for a harness root.
+ * When harness is known, always returns `~/.cursor/projects/<slug>/canvases`
+ * (directory need not exist yet — callers mkdir on write).
+ * Returns null only when neither env override nor harness root is available.
+ */
+export function resolveCanvasesDir(harnessRoot: string | null): string | null {
   const fromEnv =
     process.env.TRELLIS_CAMPAIGN_CANVAS_DIR?.trim() ||
     process.env.CURSOR_CANVAS_DIR?.trim();
@@ -37,38 +43,112 @@ function resolveCanvasesDir(harnessRoot: string | null): string | null {
   );
   if (fs.existsSync(candidate)) return candidate;
 
-  // Soft match: any project dir whose name ends with the slug or contains harness basename
+  // Soft match: prefer an existing project dir with matching slug (case).
+  // If ~/.cursor/projects is missing, still return the candidate so write can mkdir.
   const projectsRoot = path.join(os.homedir(), ".cursor", "projects");
-  if (!fs.existsSync(projectsRoot)) return null;
-  try {
-    const entries = fs.readdirSync(projectsRoot, { withFileTypes: true });
-    const exact = entries.find(
-      (e) => e.isDirectory() && e.name.toLowerCase() === slug.toLowerCase(),
-    );
-    if (exact) {
-      return path.join(projectsRoot, exact.name, "canvases");
+  if (fs.existsSync(projectsRoot)) {
+    try {
+      const entries = fs.readdirSync(projectsRoot, { withFileTypes: true });
+      const exact = entries.find(
+        (e) => e.isDirectory() && e.name.toLowerCase() === slug.toLowerCase(),
+      );
+      if (exact) {
+        return path.join(projectsRoot, exact.name, "canvases");
+      }
+    } catch {
+      // ignore — fall through to candidate
     }
-  } catch {
-    // ignore
   }
   return candidate;
+}
+
+/** True when `absPath` is under `canvasDir` (Windows case-insensitive). */
+export function isUnderCanvasDir(
+  absPath: string,
+  canvasDir: string | null,
+): boolean {
+  if (!canvasDir) return false;
+  const file = path.resolve(absPath);
+  const root = path.resolve(canvasDir);
+  if (process.platform === "win32") {
+    const f = file.toLowerCase();
+    const r = root.toLowerCase().replace(/[/\\]+$/, "");
+    return f.startsWith(`${r}\\`) || f.startsWith(`${r}/`);
+  }
+  const rel = path.relative(root, file);
+  return rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel);
+}
+
+export type CanvasWriteEvaluation = {
+  underCanvasDir: boolean;
+  usedWorkspaceFallback: boolean;
+  warnings: string[];
+  hints: string[];
+};
+
+const OPEN_HINT =
+  "Open this file in Cursor Canvas view (not a normal text editor). " +
+  "Cursor only renders .canvas.tsx under ~/.cursor/projects/<slug>/canvases/ " +
+  "(or TRELLIS_CAMPAIGN_CANVAS_DIR / CURSOR_CANVAS_DIR). " +
+  "Opening outside that folder in a normal editor shows source only — no graphics.";
+
+/**
+ * Evaluate write destination for warnings/hints after `campaign canvas` succeeds.
+ * Does not change exit code; callers print warnings on stderr.
+ */
+export function evaluateCanvasWritePath(
+  absOut: string,
+  canvasDir: string | null,
+  opts?: { usedWorkspaceFallback?: boolean },
+): CanvasWriteEvaluation {
+  const underCanvasDir = isUnderCanvasDir(absOut, canvasDir);
+  const usedWorkspaceFallback = opts?.usedWorkspaceFallback === true;
+  const warnings: string[] = [];
+  if (!underCanvasDir) {
+    warnings.push(
+      "⚠ Warning: output is outside the Cursor canvases directory" +
+        (canvasDir ? ` (${canvasDir})` : "") +
+        ". Opening this path in a normal editor shows TypeScript source only — no Canvas UI.",
+    );
+  }
+  if (usedWorkspaceFallback) {
+    warnings.push(
+      "⚠ Warning: fell back to .cstl/workspace/campaign-status/ because no harness root " +
+        "and no TRELLIS_CAMPAIGN_CANVAS_DIR / CURSOR_CANVAS_DIR were available. " +
+        "Prefer the default path under ~/.cursor/projects/<slug>/canvases/.",
+    );
+  }
+  return {
+    underCanvasDir,
+    usedWorkspaceFallback,
+    warnings,
+    hints: [OPEN_HINT],
+  };
+}
+
+export function resolveHarnessForCanvas(parentDir: string): string | null {
+  return findHarnessRoot(parentDir) ?? findHarnessRoot(process.cwd());
 }
 
 export function defaultCanvasPath(
   snapshot: CampaignStatusSnapshot,
   parentDir: string,
 ): string {
-  const harness =
-    findHarnessRoot(parentDir) ?? findHarnessRoot(process.cwd());
+  const harness = resolveHarnessForCanvas(parentDir);
   const canvases = resolveCanvasesDir(harness);
   const fileName = `campaign-${snapshot.parent.id}.canvas.tsx`;
   if (canvases) {
     return path.join(canvases, fileName);
   }
-  const base = harness
-    ? path.join(harness, ".cstl", "workspace", "campaign-status")
-    : path.join(process.cwd(), ".cstl", "workspace", "campaign-status");
+  // Last resort: no harness and no env canvas dir.
+  const base = path.join(process.cwd(), ".cstl", "workspace", "campaign-status");
   return path.join(base, fileName);
+}
+
+/** Whether `defaultCanvasPath` would use the workspace fallback for this parent. */
+export function defaultCanvasUsesWorkspaceFallback(parentDir: string): boolean {
+  const harness = resolveHarnessForCanvas(parentDir);
+  return resolveCanvasesDir(harness) === null;
 }
 
 /** Escape a JSON text so it is safe as a JS/TS expression. */

--- a/packages/cli/src/commands/campaign/index.ts
+++ b/packages/cli/src/commands/campaign/index.ts
@@ -142,11 +142,11 @@ export function registerCampaignCommand(program: Command): void {
     )
     .option(
       "-q, --quiet",
-      "Suppress stderr hints/warnings (stdout still prints the absolute path)",
+      "Suppress stderr hints/warnings and skip auto-open (stdout still prints the absolute path)",
     )
     .option(
-      "--open",
-      "Best-effort open the file via Cursor CLI (or TRELLIS_CAMPAIGN_CANVAS_OPEN=1)",
+      "--no-open",
+      "Do not launch Cursor after writing the canvas file (auto-open is on by default)",
     )
     .action(
       async (opts: {
@@ -184,13 +184,19 @@ export function registerCampaignCommand(program: Command): void {
               console.warn(`Hint: ${hint}`);
             }
           }
-          if (shouldAutoOpenCanvas({ open: opts.open === true })) {
+          // Commander: --no-open ⇒ open:false; absent ⇒ undefined (default open).
+          if (
+            shouldAutoOpenCanvas({
+              noOpen: opts.open === false,
+              quiet: opts.quiet === true,
+            })
+          ) {
             const openResult = tryOpenCanvasFile(abs);
             if (!opts.quiet) {
               if (openResult.ok) {
                 console.warn(
-                  `Hint: launched Cursor CLI on the canvas file (${openResult.detail}). ` +
-                    "If you still see source only, use Open as Canvas in the IDE.",
+                  `Hint: opened canvas file via Cursor CLI (${openResult.detail}). ` +
+                    "If the tab shows source only, use Open as Canvas / reopen from the canvases path.",
                 );
               } else {
                 console.warn(

--- a/packages/cli/src/commands/campaign/index.ts
+++ b/packages/cli/src/commands/campaign/index.ts
@@ -5,7 +5,10 @@ import { type Command } from "commander";
 import { resolveRpcUrl } from "../rpc/client.js";
 import {
   defaultCanvasPath,
-  renderCampaignCanvasTsx,
+  defaultCanvasUsesWorkspaceFallback,
+  evaluateCanvasWritePath,
+  resolveCanvasesDir,
+  resolveHarnessForCanvas,
   writeCampaignCanvas,
 } from "./canvas-render.js";
 import { composeCampaignStatus } from "./compose.js";
@@ -20,7 +23,10 @@ export { composeCampaignStatus } from "./compose.js";
 export { capLabelForKind } from "./kind-map.js";
 export {
   defaultCanvasPath,
+  evaluateCanvasWritePath,
+  isUnderCanvasDir,
   renderCampaignCanvasTsx,
+  resolveCanvasesDir,
   writeCampaignCanvas,
 } from "./canvas-render.js";
 export {
@@ -137,10 +143,26 @@ export function registerCampaignCommand(program: Command): void {
             parentDir,
             rpcUrl: opts.url,
           });
+          const explicitOut = opts.out?.trim();
           const out =
-            opts.out?.trim() || defaultCanvasPath(snapshot, parentDir);
+            explicitOut || defaultCanvasPath(snapshot, parentDir);
+          const usedWorkspaceFallback =
+            !explicitOut && defaultCanvasUsesWorkspaceFallback(parentDir);
           const abs = writeCampaignCanvas(snapshot, out);
+          const canvasDir = resolveCanvasesDir(
+            resolveHarnessForCanvas(parentDir),
+          );
+          const evaluation = evaluateCanvasWritePath(abs, canvasDir, {
+            usedWorkspaceFallback,
+          });
+          // stdout: absolute path only (script-friendly)
           console.log(abs);
+          for (const warning of evaluation.warnings) {
+            console.warn(warning);
+          }
+          for (const hint of evaluation.hints) {
+            console.warn(`Hint: ${hint}`);
+          }
         } catch (error) {
           console.error(
             error instanceof Error ? error.message : String(error),

--- a/packages/cli/src/commands/campaign/index.ts
+++ b/packages/cli/src/commands/campaign/index.ts
@@ -9,6 +9,8 @@ import {
   evaluateCanvasWritePath,
   resolveCanvasesDir,
   resolveHarnessForCanvas,
+  shouldAutoOpenCanvas,
+  tryOpenCanvasFile,
   writeCampaignCanvas,
 } from "./canvas-render.js";
 import { composeCampaignStatus } from "./compose.js";
@@ -25,8 +27,11 @@ export {
   defaultCanvasPath,
   evaluateCanvasWritePath,
   isUnderCanvasDir,
+  looksLikeCursorCanvasesPath,
   renderCampaignCanvasTsx,
   resolveCanvasesDir,
+  softMatchCanvasesDir,
+  tryOpenCanvasFile,
   writeCampaignCanvas,
 } from "./canvas-render.js";
 export {
@@ -135,8 +140,22 @@ export function registerCampaignCommand(program: Command): void {
       "--out <path>",
       "Canvas output path (default: Cursor projects/.../canvases/campaign-<id>.canvas.tsx)",
     )
+    .option(
+      "-q, --quiet",
+      "Suppress stderr hints/warnings (stdout still prints the absolute path)",
+    )
+    .option(
+      "--open",
+      "Best-effort open the file via Cursor CLI (or TRELLIS_CAMPAIGN_CANVAS_OPEN=1)",
+    )
     .action(
-      async (opts: { parent?: string; url?: string; out?: string }) => {
+      async (opts: {
+        parent?: string;
+        url?: string;
+        out?: string;
+        quiet?: boolean;
+        open?: boolean;
+      }) => {
         try {
           const parentDir = resolveParentDir(opts.parent);
           const snapshot = await composeCampaignStatus({
@@ -157,11 +176,29 @@ export function registerCampaignCommand(program: Command): void {
           });
           // stdout: absolute path only (script-friendly)
           console.log(abs);
-          for (const warning of evaluation.warnings) {
-            console.warn(warning);
+          if (!opts.quiet) {
+            for (const warning of evaluation.warnings) {
+              console.warn(warning);
+            }
+            for (const hint of evaluation.hints) {
+              console.warn(`Hint: ${hint}`);
+            }
           }
-          for (const hint of evaluation.hints) {
-            console.warn(`Hint: ${hint}`);
+          if (shouldAutoOpenCanvas({ open: opts.open === true })) {
+            const openResult = tryOpenCanvasFile(abs);
+            if (!opts.quiet) {
+              if (openResult.ok) {
+                console.warn(
+                  `Hint: launched Cursor CLI on the canvas file (${openResult.detail}). ` +
+                    "If you still see source only, use Open as Canvas in the IDE.",
+                );
+              } else {
+                console.warn(
+                  `⚠ Warning: could not auto-open Canvas (${openResult.detail}). ` +
+                    "Open the printed path in Cursor Canvas view manually.",
+                );
+              }
+            }
           }
         } catch (error) {
           console.error(

--- a/packages/cli/test/commands/campaign-canvas.test.ts
+++ b/packages/cli/test/commands/campaign-canvas.test.ts
@@ -9,8 +9,11 @@ import {
   defaultCanvasPath,
   evaluateCanvasWritePath,
   isUnderCanvasDir,
+  looksLikeCursorCanvasesPath,
   renderCampaignCanvasTsx,
   resolveCanvasesDir,
+  shouldAutoOpenCanvas,
+  softMatchCanvasesDir,
   writeCampaignCanvas,
 } from "../../src/commands/campaign/canvas-render.js";
 import { composeCampaignStatus } from "../../src/commands/campaign/compose.js";
@@ -52,6 +55,9 @@ const fixtureParent: CampaignParentSnapshot = {
 const envKeys = [
   "TRELLIS_CAMPAIGN_CANVAS_DIR",
   "CURSOR_CANVAS_DIR",
+  "TRELLIS_CURSOR_PROJECT_SLUG",
+  "TRELLIS_CAMPAIGN_CANVAS_OPEN",
+  "CURSOR_BIN",
 ] as const;
 
 afterEach(() => {
@@ -62,12 +68,18 @@ afterEach(() => {
 });
 
 describe("cursorProjectSlug", () => {
-  it("maps Windows harness roots to Cursor project slugs", () => {
+  it("maps drive-letter roots to Cursor-style slugs (encoding only)", () => {
     expect(cursorProjectSlug("D:\\MyHarness")).toBe("d-MyHarness");
+  });
+
+  it("maps POSIX absolute paths when resolved without a Windows drive", () => {
+    // On Windows, path.resolve("/home/...") becomes "<drive>:/home/..." — skip.
+    if (process.platform === "win32") return;
+    expect(cursorProjectSlug("/home/user/acme")).toBe("home-user-acme");
   });
 });
 
-describe("isUnderCanvasDir / evaluateCanvasWritePath", () => {
+describe("isUnderCanvasDir / looksLike / evaluateCanvasWritePath", () => {
   it("detects paths under the canvases directory", () => {
     const canvasDir = path.join(os.tmpdir(), "canvases-under-test");
     const inside = path.join(canvasDir, "campaign-x.canvas.tsx");
@@ -75,6 +87,38 @@ describe("isUnderCanvasDir / evaluateCanvasWritePath", () => {
     expect(isUnderCanvasDir(inside, canvasDir)).toBe(true);
     expect(isUnderCanvasDir(outside, canvasDir)).toBe(false);
     expect(isUnderCanvasDir(inside, null)).toBe(false);
+  });
+
+  it("looksLikeCursorCanvasesPath matches any ~/.cursor/projects/*/canvases file", () => {
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "canvas-like-"));
+    const inside = path.join(
+      fakeHome,
+      ".cursor",
+      "projects",
+      "any-user-slug",
+      "canvases",
+      "campaign.canvas.tsx",
+    );
+    expect(looksLikeCursorCanvasesPath(inside)).toBe(true);
+    expect(
+      looksLikeCursorCanvasesPath(
+        path.join(fakeHome, "workspace", "out.canvas.tsx"),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not false-warn when canvasDir is null but --out is under canvases", () => {
+    const under = path.join(
+      os.homedir(),
+      ".cursor",
+      "projects",
+      "user-workspace",
+      "canvases",
+      "campaign.canvas.tsx",
+    );
+    const evalUnder = evaluateCanvasWritePath(under, null);
+    expect(evalUnder.underCanvasDir).toBe(true);
+    expect(evalUnder.warnings).toHaveLength(0);
   });
 
   it("warns when outside canvases and always includes open hint", () => {
@@ -107,6 +151,27 @@ describe("isUnderCanvasDir / evaluateCanvasWritePath", () => {
   });
 });
 
+describe("softMatchCanvasesDir", () => {
+  it("matches case and underscore variants, not longer nested names", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "soft-canvas-"));
+    fs.mkdirSync(path.join(root, "D_Acme_App", "canvases"), { recursive: true });
+    fs.mkdirSync(path.join(root, "d-Acme-App-extra", "canvases"), {
+      recursive: true,
+    });
+    fs.mkdirSync(path.join(root, "1234567890", "canvases"), { recursive: true });
+
+    const matched = softMatchCanvasesDir(root, "d-Acme-App", root);
+    expect(matched).toBe(path.join(root, "D_Acme_App", "canvases"));
+
+    // No exact/normalized match → null (caller mkdir's canonical slug)
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), "soft-empty-"));
+    fs.mkdirSync(path.join(empty, "d-Acme-App-extra", "canvases"), {
+      recursive: true,
+    });
+    expect(softMatchCanvasesDir(empty, "d-Acme-App", empty)).toBeNull();
+  });
+});
+
 describe("resolveCanvasesDir / defaultCanvasPath", () => {
   it("honors TRELLIS_CAMPAIGN_CANVAS_DIR", () => {
     const dir = path.join(os.tmpdir(), "env-canvas-dir");
@@ -114,13 +179,24 @@ describe("resolveCanvasesDir / defaultCanvasPath", () => {
     expect(resolveCanvasesDir(null)).toBe(path.resolve(dir));
   });
 
+  it("honors TRELLIS_CURSOR_PROJECT_SLUG when harness is known", () => {
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "canvas-slug-"));
+    vi.spyOn(os, "homedir").mockReturnValue(fakeHome);
+    process.env.TRELLIS_CURSOR_PROJECT_SLUG = "custom-user-slug";
+    const harness = path.join(fakeHome, "WhateverRoot");
+    expect(resolveCanvasesDir(harness)).toBe(
+      path.join(fakeHome, ".cursor", "projects", "custom-user-slug", "canvases"),
+    );
+  });
+
   it("returns canvases candidate when harness is known even if projects dir is missing", () => {
     const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "canvas-home-"));
-    const harness = "D:\\MyHarness";
+    const harness = path.join(fakeHome, "AcmeApp");
     vi.spyOn(os, "homedir").mockReturnValue(fakeHome);
+    const slug = cursorProjectSlug(harness);
     const resolved = resolveCanvasesDir(harness);
     expect(resolved).toBe(
-      path.join(fakeHome, ".cursor", "projects", "d-MyHarness", "canvases"),
+      path.join(fakeHome, ".cursor", "projects", slug, "canvases"),
     );
     expect(fs.existsSync(path.join(fakeHome, ".cursor", "projects"))).toBe(
       false,
@@ -136,14 +212,36 @@ describe("resolveCanvasesDir / defaultCanvasPath", () => {
       },
     });
     const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "canvas-home2-"));
+    const harnessRoot = path.join(fakeHome, "PortableHarness");
+    // findHarnessRoot requires .cstl/scripts/task.py (not merely .cstl/)
+    const taskPy = path.join(harnessRoot, ".cstl", "scripts", "task.py");
+    fs.mkdirSync(path.dirname(taskPy), { recursive: true });
+    fs.writeFileSync(taskPy, "# test fixture\n", "utf8");
     vi.spyOn(os, "homedir").mockReturnValue(fakeHome);
-    // parentDir with .cstl so findHarnessRoot can walk — use real harness if available
-    const harnessRoot = path.resolve("D:/MyHarness");
+    const slug = cursorProjectSlug(harnessRoot);
     const out = defaultCanvasPath(snapshot, harnessRoot);
-    expect(out.replace(/\\/g, "/")).toMatch(
-      /\/\.cursor\/projects\/d-MyHarness\/canvases\/campaign-08-01-demo-parent\.canvas\.tsx$/,
+    expect(out.replace(/\\/g, "/")).toBe(
+      path
+        .join(
+          fakeHome,
+          ".cursor",
+          "projects",
+          slug,
+          "canvases",
+          "campaign-08-01-demo-parent.canvas.tsx",
+        )
+        .replace(/\\/g, "/"),
     );
     expect(out).not.toMatch(/campaign-status/);
+  });
+});
+
+describe("shouldAutoOpenCanvas", () => {
+  it("respects --open and TRELLIS_CAMPAIGN_CANVAS_OPEN", () => {
+    expect(shouldAutoOpenCanvas({})).toBe(false);
+    expect(shouldAutoOpenCanvas({ open: true })).toBe(true);
+    process.env.TRELLIS_CAMPAIGN_CANVAS_OPEN = "1";
+    expect(shouldAutoOpenCanvas({})).toBe(true);
   });
 });
 

--- a/packages/cli/test/commands/campaign-canvas.test.ts
+++ b/packages/cli/test/commands/campaign-canvas.test.ts
@@ -2,12 +2,15 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   cursorProjectSlug,
   defaultCanvasPath,
+  evaluateCanvasWritePath,
+  isUnderCanvasDir,
   renderCampaignCanvasTsx,
+  resolveCanvasesDir,
   writeCampaignCanvas,
 } from "../../src/commands/campaign/canvas-render.js";
 import { composeCampaignStatus } from "../../src/commands/campaign/compose.js";
@@ -46,9 +49,101 @@ const fixtureParent: CampaignParentSnapshot = {
   integrationQueue: [],
 };
 
+const envKeys = [
+  "TRELLIS_CAMPAIGN_CANVAS_DIR",
+  "CURSOR_CANVAS_DIR",
+] as const;
+
+afterEach(() => {
+  for (const key of envKeys) {
+    delete process.env[key];
+  }
+  vi.restoreAllMocks();
+});
+
 describe("cursorProjectSlug", () => {
   it("maps Windows harness roots to Cursor project slugs", () => {
     expect(cursorProjectSlug("D:\\MyHarness")).toBe("d-MyHarness");
+  });
+});
+
+describe("isUnderCanvasDir / evaluateCanvasWritePath", () => {
+  it("detects paths under the canvases directory", () => {
+    const canvasDir = path.join(os.tmpdir(), "canvases-under-test");
+    const inside = path.join(canvasDir, "campaign-x.canvas.tsx");
+    const outside = path.join(os.tmpdir(), "elsewhere", "campaign-x.canvas.tsx");
+    expect(isUnderCanvasDir(inside, canvasDir)).toBe(true);
+    expect(isUnderCanvasDir(outside, canvasDir)).toBe(false);
+    expect(isUnderCanvasDir(inside, null)).toBe(false);
+  });
+
+  it("warns when outside canvases and always includes open hint", () => {
+    const canvasDir = path.join(os.tmpdir(), "canvases-eval");
+    const outside = path.join(os.tmpdir(), "workspace", "out.canvas.tsx");
+    const evalOutside = evaluateCanvasWritePath(outside, canvasDir);
+    expect(evalOutside.underCanvasDir).toBe(false);
+    expect(evalOutside.warnings.some((w) => w.includes("⚠ Warning"))).toBe(
+      true,
+    );
+    expect(evalOutside.hints.some((h) => /Canvas view/i.test(h))).toBe(true);
+
+    const inside = path.join(canvasDir, "ok.canvas.tsx");
+    const evalInside = evaluateCanvasWritePath(inside, canvasDir);
+    expect(evalInside.underCanvasDir).toBe(true);
+    expect(evalInside.warnings).toHaveLength(0);
+    expect(evalInside.hints.length).toBeGreaterThan(0);
+  });
+
+  it("warns on workspace fallback even when path checks are soft", () => {
+    const result = evaluateCanvasWritePath(
+      path.join(os.tmpdir(), "fallback.canvas.tsx"),
+      null,
+      { usedWorkspaceFallback: true },
+    );
+    expect(result.usedWorkspaceFallback).toBe(true);
+    expect(
+      result.warnings.some((w) => w.includes("campaign-status")),
+    ).toBe(true);
+  });
+});
+
+describe("resolveCanvasesDir / defaultCanvasPath", () => {
+  it("honors TRELLIS_CAMPAIGN_CANVAS_DIR", () => {
+    const dir = path.join(os.tmpdir(), "env-canvas-dir");
+    process.env.TRELLIS_CAMPAIGN_CANVAS_DIR = dir;
+    expect(resolveCanvasesDir(null)).toBe(path.resolve(dir));
+  });
+
+  it("returns canvases candidate when harness is known even if projects dir is missing", () => {
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "canvas-home-"));
+    const harness = "D:\\MyHarness";
+    vi.spyOn(os, "homedir").mockReturnValue(fakeHome);
+    const resolved = resolveCanvasesDir(harness);
+    expect(resolved).toBe(
+      path.join(fakeHome, ".cursor", "projects", "d-MyHarness", "canvases"),
+    );
+    expect(fs.existsSync(path.join(fakeHome, ".cursor", "projects"))).toBe(
+      false,
+    );
+  });
+
+  it("defaultCanvasPath prefers canvases over workspace when harness resolves", async () => {
+    const snapshot = await composeCampaignStatus({
+      parentDir: "/unused",
+      loadTrellis: async () => fixtureParent,
+      fetchRpcStatus: async () => {
+        throw new Error("offline");
+      },
+    });
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "canvas-home2-"));
+    vi.spyOn(os, "homedir").mockReturnValue(fakeHome);
+    // parentDir with .cstl so findHarnessRoot can walk — use real harness if available
+    const harnessRoot = path.resolve("D:/MyHarness");
+    const out = defaultCanvasPath(snapshot, harnessRoot);
+    expect(out.replace(/\\/g, "/")).toMatch(
+      /\/\.cursor\/projects\/d-MyHarness\/canvases\/campaign-08-01-demo-parent\.canvas\.tsx$/,
+    );
+    expect(out).not.toMatch(/campaign-status/);
   });
 });
 

--- a/packages/cli/test/commands/campaign-canvas.test.ts
+++ b/packages/cli/test/commands/campaign-canvas.test.ts
@@ -237,10 +237,15 @@ describe("resolveCanvasesDir / defaultCanvasPath", () => {
 });
 
 describe("shouldAutoOpenCanvas", () => {
-  it("respects --open and TRELLIS_CAMPAIGN_CANVAS_OPEN", () => {
-    expect(shouldAutoOpenCanvas({})).toBe(false);
+  it("defaults to open; quiet/noOpen/env can disable", () => {
+    expect(shouldAutoOpenCanvas({})).toBe(true);
     expect(shouldAutoOpenCanvas({ open: true })).toBe(true);
+    expect(shouldAutoOpenCanvas({ quiet: true })).toBe(false);
+    expect(shouldAutoOpenCanvas({ noOpen: true })).toBe(false);
+    process.env.TRELLIS_CAMPAIGN_CANVAS_OPEN = "0";
+    expect(shouldAutoOpenCanvas({})).toBe(false);
     process.env.TRELLIS_CAMPAIGN_CANVAS_OPEN = "1";
+    expect(shouldAutoOpenCanvas({ quiet: true })).toBe(false);
     expect(shouldAutoOpenCanvas({})).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Warn + hint when `cstl campaign canvas` writes outside Cursor `canvases/` (or env canvas dirs); stdout still prints the absolute path only.
- When harness is known, always prefer `~/.cursor/projects/<slug>/canvases` (mkdir on write) instead of falling back because `~/.cursor/projects` is missing.
- Document correct open path and `--out` anti-pattern in `docs/campaign-ui.md`.

## Test plan
- [x] `pnpm --filter @blxzer/cursor-trellis exec vitest run test/commands/campaign-canvas.test.ts` (9 passed)
- [ ] Dogfood: default write opens in Canvas view; `--out` to `.cstl/workspace/...` prints warning and source-only in normal editor

Made with [Cursor](https://cursor.com)