### PR TITLE
fix(cli): release-gate empty mcp.json + mirror sync

### DIFF
--- a/packages/cli/src/utils/project-capabilities.ts
+++ b/packages/cli/src/utils/project-capabilities.ts
@@ -1061,7 +1061,21 @@ export function buildProjectCapabilityTemplates(
         : options?.cwd
           ? loadExistingMcpServers(options.cwd)
           : null;
-    files.set(".cursor/mcp.json", renderMcpJson(selectedIds, existing));
+    const desiredServers = uniqueMcpServers(selectedIds);
+    const existingKeys = Object.keys(existing ?? {});
+    const mcpPathExists =
+      typeof options?.cwd === "string" &&
+      fs.existsSync(path.join(options.cwd, ".cursor", "mcp.json"));
+    // Do not create an empty `.cursor/mcp.json` on fresh Cursor init with no
+    // MCP capabilities selected — that leaves a useless file and breaks
+    // uninstall "project is clean" expectations.
+    if (
+      desiredServers.length > 0 ||
+      existingKeys.length > 0 ||
+      mcpPathExists
+    ) {
+      files.set(".cursor/mcp.json", renderMcpJson(selectedIds, existing));
+    }
   }
 
   return files;


### PR DESCRIPTION
## Summary
- Do not write empty `.cursor/mcp.json` on Cursor init when no MCP capabilities are selected.
- Sync dogfood `.cursor/rules/retrieval-routing.mdc` with the CLI template (mirror-check).

## Test plan
- [x] init/uninstall/mirror-check previously failing suites (53 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small conditional around when init writes one config file; behavior change is intentional for clean init/uninstall with no security or data impact.
> 
> **Overview**
> **Cursor template generation** now gates `.cursor/mcp.json` in `buildProjectCapabilityTemplates`: the file is added to the init template map only when the selection includes at least one MCP-backed capability (via `uniqueMcpServers`), the loaded existing config has server keys, or `.cursor/mcp.json` already exists on disk.
> 
> Previously, choosing Cursor with no MCP capabilities (e.g. only `cursor-sdk`) could still emit an empty or useless `mcp.json`, which broke uninstall “project is clean” checks and left noise in fresh projects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f21df71f52ef9e6086f7dcbab7229cb2ab0ee838. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->