### PR TITLE
docs(release): 0.3.5 changelog and upgrade notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,19 @@ cstl init --cursor
 
 Optional: `cstl init --cursor --cursor2plus` materializes a **per-repo** Cursor++ BYOK bundle (not a global either/or choice). Native and BYOK can coexist across projects on one machine — see [Native and BYOK coexistence](docs/cursor.md#native-and-byok-coexistence-not-eitheror).
 
+## Upgrade to 0.3.5
+
+```powershell
+npm install -g @blxzer/cursor-trellis@0.3.5
+# or: cstl upgrade
+cd /path/to/project
+cstl update -f --migrate
+# optional full capabilities:
+cstl init --cursor --capability all -y -f
+```
+
+Highlights: Campaign Canvas path/open guard (see [campaign-ui](docs/campaign-ui.md)), campaign MCP NDJSON host fix, smart-search **0.2** + External-knowledge gate, `cstl sdk run` explicit `--task` binding. Details: [CHANGELOG](packages/cli/CHANGELOG.md#035---2026-08-05).
+
 ## Upgrade from 0.3.0 (v0.3.1)
 
 v0.3.1 moves the cursor-trellis **runtime directory** from `.trellis/` to **`.cstl/`** so upstream [mindfold-ai/Trellis](https://github.com/mindfold-ai/Trellis) can keep `.trellis/` in the same repository. AGENTS.md managed blocks use `<!-- CSTL:START -->` markers.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -11,6 +11,23 @@ SemVer: [semver.org](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.5] - 2026-08-05
+
+### Added
+
+- **feat(sdk)**: `cstl sdk run` injects an explicit `--task` binding into the agent prompt (BOUND contract).
+- **feat(campaign)**: Campaign Canvas open-path guard — default write under `~/.cursor/projects/<slug>/canvases/`; auto-open via Cursor CLI after write; `--quiet` / `--no-open`; env overrides `TRELLIS_CAMPAIGN_CANVAS_DIR` / `CURSOR_CANVAS_DIR` / `TRELLIS_CURSOR_PROJECT_SLUG` / `CURSOR_BIN` / `TRELLIS_CAMPAIGN_CANVAS_OPEN`.
+- **feat(cli)**: Adapt to **@blxzer/smart-search ^0.2.0**; External-knowledge gate in bundled agents/skills and retrieval docs (search when the world/API moved; skip when truth is in-repo).
+
+### Fixed
+
+- **fix(campaign)**: Campaign MCP stdio speaks **NDJSON** (Cursor / MCP SDK host), not LSP Content-Length framing.
+- **fix(cli)**: Do not create an empty `.cursor/mcp.json` on Cursor init when no MCP capabilities are selected (uninstall / clean-project gate).
+
+### Changed
+
+- **docs(campaign)**: `docs/campaign-ui.md` — portable canvases path, open-by-default, `--out` anti-pattern (source-only outside canvases).
+
 ## [0.3.4] - 2026-07-04
 
 ### Added


### PR DESCRIPTION
## Summary
- CHANGELOG 0.3.5 + README upgrade section after npm publish.

## Test plan
- [x] Manual review of changelog vs shipped commits

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no behavioral or dependency changes in this PR.
> 
> **Overview**
> Documents the **0.3.5** npm release for reviewers and upgraders—no runtime or CLI code in this diff.
> 
> **README** gains an **Upgrade to 0.3.5** block: pin `@blxzer/cursor-trellis@0.3.5` (or `cstl upgrade`), run `cstl update -f --migrate`, optional `cstl init --cursor --capability all`, plus a short highlights list linking to `docs/campaign-ui.md` and the changelog anchor.
> 
> **`packages/cli/CHANGELOG.md`** adds the **[0.3.5] - 2026-08-05** entry summarizing what shipped: SDK `--task` binding, Campaign Canvas path/open guard, smart-search **^0.2.0** + External-knowledge gate, campaign MCP **NDJSON** fix, and skipping empty `.cursor/mcp.json` on init when no MCP capabilities are selected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e0223f60bcc21a438afca90bcd7ff84439a4185. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->