### PR TITLE
fix(agents): move harness thin-connect notes out of managed CSTL block

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,14 +3,14 @@
 
 These instructions are for AI assistants working in this project.
 
-**Thin-connect to the harness root instance (2026-08-16 决策落地)**: this repo has **no independent `.cstl/`** (its local instance was archived to `D:\MyHarness\.tmp\cstl-legacy-cursor-trellis-0.3.3`). The cstl runtime and all working knowledge live in the **harness root instance** `D:\MyHarness\.cstl`:
+This project is managed by cursor-trellis. The working knowledge you need lives under `.cstl/`:
 
-- `D:\MyHarness\.cstl/workflow.md` — development phases, when to create tasks, skill routing
-- `D:\MyHarness\.cstl/spec/` — package- and layer-scoped coding guidelines (read before writing code in a given layer)
-- `D:\MyHarness\.cstl/workspace/` — per-developer journals and session traces
-- `D:\MyHarness\.cstl/tasks/` — active and archived tasks (PRDs, research, jsonl context)
+- `.cstl/workflow.md` — development phases, when to create tasks, skill routing
+- `.cstl/spec/` — package- and layer-scoped coding guidelines (read before writing code in a given layer)
+- `.cstl/workspace/` — per-developer journals and session traces
+- `.cstl/tasks/` — active and archived tasks (PRDs, research, jsonl context)
 
-When a cstl command is available on Cursor (e.g. `cstl-finish-work`, `cstl-continue`), prefer it over manual steps. CLI/hook scripts run from this directory resolve to the root instance automatically (nearest-`.cstl` upward lookup). Tasks for this repo live under `D:\MyHarness\.cstl\tasks/`; mark them with `--package cursor-trellis` when creating.
+If a cstl command is available on Cursor (e.g. `cstl-finish-work`, `cstl-continue`), prefer it over manual steps.
 
 ## Command surface (what is user-invocable vs internal)
 
@@ -56,6 +56,17 @@ For **any external / current / web fact**, run **`python ./.cstl/scripts/run_sma
 Managed by cursor-trellis. Edits outside this block are preserved; edits inside may be overwritten by a future `cstl update`.
 
 <!-- CSTL:END -->
+
+## Thin-connect to harness root (maintainers, 2026-08-16 决策落地)
+
+This repo has **no independent `.cstl/`** (its local instance was archived to `D:\MyHarness\.tmp\cstl-legacy-cursor-trellis-0.3.3`). The cstl runtime and all working knowledge live in the **harness root instance** `D:\MyHarness\.cstl`:
+
+- `D:\MyHarness\.cstl/workflow.md` — development phases, when to create tasks, skill routing
+- `D:\MyHarness\.cstl/spec/` — package- and layer-scoped coding guidelines (read before writing code in a given layer)
+- `D:\MyHarness\.cstl/workspace/` — per-developer journals and session traces
+- `D:\MyHarness\.cstl/tasks/` — active and archived tasks (PRDs, research, jsonl context)
+
+CLI/hook scripts run from this directory resolve to the root instance automatically (nearest-`.cstl` upward lookup). Tasks for this repo live under `D:\MyHarness\.cstl\tasks/`; mark them with `--package cursor-trellis` when creating.
 
 ## Mindfold harness (maintainers)
 


### PR DESCRIPTION
修复 mirror-check CI 失败（run 32238121715）。

thin-connect 提交把 harness 定制写进了 AGENTS.md 的 CSTL 托管块（CSTL:START..END），mirror-check 将该块与 CLI 模板比较 → content differs。

改动：定制说明移到 CSTL:END 之后（块外内容 cstl 保证保留），托管块恢复模板原文。模板保持通用，不影响发布产物。

验证：本地 pnpm mirror-check passed。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only restructuring in AGENTS.md with no runtime or security impact; reduces CI drift risk by aligning the managed block with the template.
> 
> **Overview**
> Fixes **mirror-check** CI by restoring `AGENTS.md`’s `CSTL:START`…`CSTL:END` block to the **generic CLI template** (`.cstl/` paths and standard cstl wording). Harness-specific **thin-connect** notes (no local `.cstl/`, runtime at `D:\MyHarness\.cstl`, task `--package cursor-trellis`, upward lookup) were incorrectly inside that managed block, so the mirror diff flagged “content differs.”
> 
> Those maintainer notes are **moved to a new section immediately after `CSTL:END`**, where `cstl update` is designed to preserve out-of-block content. The shipped template stays generic; local harness policy remains documented for agents working in this repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 340d4cd0ca6f778cf0e3921699c905e4f018a21a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->